### PR TITLE
Relax version pinnings of numpy, netCDF4, and xarray.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - click
     - dask
     - h5py
-    - netCDF4 <1.7.1
-    - numpy >=1.20,<2
+    - netCDF4
+    - numpy >=1.20
     - pandas >=0.24.0
     - pep8 >=1.7.1
     - pygrib
@@ -38,7 +38,7 @@ requirements:
     - scipy >=1.3.0
     - spectral >=0.19
     - utm
-    - xarray >2023,<2024.1.1
+    - xarray
 
 test:
   imports:


### PR DESCRIPTION
This removes the maximum version pinnings for numpy and netCDF4 and the entire pinning of xarray. This has already been done in the isofit main repository in https://github.com/isofit/isofit/commit/a4a86c5dc463adf2521cc3ca1a23e74177f0bf8d and https://github.com/isofit/isofit/commit/268e081b726d6d2e1fc2a90fd15d1c3d787c4017.

Note that these version pinnings currently block me from updating the EnPT environment to Python 3.13.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
